### PR TITLE
README: Hexner -> Hetzner name fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 I've been having a blast poking around at [1BRC](https://github.com/gunnarmorling/1brc), thanks [Gunnar Morling](https://www.morling.dev/blog/one-billion-row-challenge/)! I couldn't help but go down the rabbit hole :)
 
 I appreciate all the other participants who shared their solutions. Many of the optimizations here were inspired by what others discovered
-and then I pushed it a little farther. For the moment on Jan 21 2024 this might be the fastest known implementation on the Hexner CCX33 hardware but I hope this is a useful stepping stone for others on the way to even higher perf.
+and then I pushed it a little farther. For the moment on Jan 21 2024 this might be the fastest known implementation on the [Hetzner CCX33](https://www.hetzner.com/cloud/) hardware but I hope this is a useful stepping stone for others on the way to even higher perf.
 
-In order to do benchmarking I grabbed access to the Hexner CCX33 (8 cores) hoping to get some numbers that are comparable to the official Java leaderboard 
+In order to do benchmarking I grabbed access to the [Hetzner CCX33](https://www.hetzner.com/cloud/) (8 cores) hoping to get some numbers that are comparable to the official Java leaderboard 
 that Gunnar is running. Gunnar is far more diligent than I am however so I just ran a few benchmarks against some of the other really speedy
 unofficial implementations that I was aware of to establish some frame of reference.
 
@@ -22,7 +22,7 @@ unofficial implementations that I was aware of to establish some frame of refere
 **Update 1/22**:
 @buybackoff kindly added this entry to his [cross-language 1BRC results](https://hotforknowledge.com/2024/01/13/1brc-in-dotnet-among-fastest-on-linux-my-optimization-journey/#results) so now I feel better that others were able to reproduce it. Unlike my data he
 actually keeps his up-to-date :) At the moment on his machine @lehuyduc's updated entry is the leader on the 10-K variation and this one is the leader on the default data.
-A little more benchmarking on some of the top Java entries suggests my CCX33 instance posted times 5-10% better than the same entries on Gunnar's machine. @lehuyduc also pointed out that Gunnar moved to using the Hexner AX161 instead and that the input data generators aren't deterministic so it remains challenging to compare results across different benchmarking environments without a good amount of fudge factor.
+A little more benchmarking on some of the top Java entries suggests my CCX33 instance posted times 5-10% better than the same entries on Gunnar's machine. @lehuyduc also pointed out that Gunnar moved to using the [Hetzner AX161](https://www.hetzner.com/dedicated-rootserver/ax161/) instead and that the input data generators aren't deterministic so it remains challenging to compare results across different benchmarking environments without a good amount of fudge factor.
 **End Updates**
 
 At the moment the top entries on [Gunnar's official leaderboard](https://github.com/gunnarmorling/1brc/tree/main?tab=readme-ov-file#results) are clocking in around ~2.5s for the default data on similar hardware so this approach is either a substantial improvement or something fishy is going on. I'm hoping at least a few other folks will run this solution and sanity check that this is a reproducible result before I put too much credence in it. As far as I know this solution is not using any [Yolo Optimizations](https://hotforknowledge.com/2024/01/13/1brc-in-dotnet-among-fastest-on-linux-my-optimization-journey/). It may not be performant on pathological input but it is intended to be always correct.


### PR DESCRIPTION
It took me a while to google this hardware. Turned out the name was misspelled. I also added the URLs for easier discovery.